### PR TITLE
Upgrade builder to go 1.13

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine
+FROM golang:1.13-alpine
 
 RUN apk add --no-cache git gcc musl-dev
 


### PR DESCRIPTION
Fixes https://github.com/abiosoft/caddy-docker/issues/238